### PR TITLE
Fixing the Lambda authorizer permissions error

### DIFF
--- a/avp-authorizer-cf-template.yaml
+++ b/avp-authorizer-cf-template.yaml
@@ -105,6 +105,12 @@ Resources:
       RestApiId: !Ref SampleRestApi
       AuthorizerUri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${AVPAuthorizerLambdaFunction.Arn}/invocations"
       AuthorizerResultTtlInSeconds: 300
+      AuthorizerCredentials: !GetAtt 
+        - AVPAuthorizerLambdaExecutionRole
+        - Arn
+    DependsOn:
+      - AVPAuthorizerLambdaFunction
+      - AVPAuthorizerLambdaExecutionRole
 
   AVPAuthorizerLambdaFunction:
     Type: AWS::Lambda::Function


### PR DESCRIPTION
Lambda authorizer returns the following error:

> Execution failed due to configuration error: Invalid permissions on Lambda function

The provided changes fix it.